### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/eCommApp/src/components/AdminPage.tsx
+++ b/eCommApp/src/components/AdminPage.tsx
@@ -18,7 +18,7 @@ const AdminPage = () => {
                         {/* Display error message above the input */}
                         {errorMessage && (
                             <div style={{ color: 'red', marginBottom: '0.5rem' }}>
-                                <span dangerouslySetInnerHTML={{ __html: errorMessage }} />
+                                <span style={{ whiteSpace: 'pre-line' }}>{errorMessage}</span>
                             </div>
                         )}
                         <label htmlFor="salePercent">Set Sale Percent (% off for all items): </label>


### PR DESCRIPTION
Potential fix for [https://github.com/Chinjila/hol-copilot-lab/security/code-scanning/2](https://github.com/Chinjila/hol-copilot-lab/security/code-scanning/2)

In general, the fix is to avoid interpreting user-controlled strings as HTML. Instead, render them as plain text so React can automatically escape any meta-characters, or, if HTML is truly required, sanitize the string with a robust HTML sanitizer before passing it to `dangerouslySetInnerHTML`.

For this component, the simplest and safest fix without changing the user-visible functionality is to stop using `dangerouslySetInnerHTML` and render `errorMessage` as normal text. The only reason `dangerouslySetInnerHTML` might have been used is to handle line breaks in the error message; we can achieve the same using `white-space: pre-line` (or similar CSS) so that `\n` characters are shown as line breaks without needing HTML injection. Concretely, in `eCommApp/src/components/AdminPage.tsx`, lines 20–22 should be updated so that:
- The `<span>` no longer uses `dangerouslySetInnerHTML`.
- The `errorMessage` is rendered directly as `{errorMessage}`.
- Add a `whiteSpace: 'pre-line'` style (or a CSS class) so that the newlines in the template string display correctly.

No new imports or external dependencies are needed; this is purely a JSX change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
